### PR TITLE
refactor: import types with type keyword for verbatimModuleSyntax enabled rule

### DIFF
--- a/modules/ahap/index.ts
+++ b/modules/ahap/index.ts
@@ -1,13 +1,13 @@
 import {
   NativeModulesProxy,
   EventEmitter,
-  Subscription,
+  type Subscription,
 } from "expo-modules-core";
 
 // Import the native module. On web, it will be resolved to Ahap.web.ts
 // and on native platforms to Ahap.ts
 import AhapModule from "./src/AhapModule";
-import { ChangeEventPayload } from "./src/Ahap.types";
+import type { ChangeEventPayload } from "./src/Ahap.types";
 
 /**
  * Parameters used to modify individual haptic and/or audio events.


### PR DESCRIPTION
Getting an error with `verbatimModuleSyntax` rule enabled, this PR addresses it by importing the types with the `type` keyword.

Not sure why this is being flagged by TS tbh, I have `node_modules` as part of the `exclude` list